### PR TITLE
Update API URLs and add TODOs in Choose-Platform branch

### DIFF
--- a/app/src/main/java/chat/revolt/api/RevoltAPI.kt
+++ b/app/src/main/java/chat/revolt/api/RevoltAPI.kt
@@ -97,9 +97,11 @@ private val PLATFORM_URLS = mapOf(
         january = "https://a-pep.peptide.chat/january",
         app = "https://peptide.chat",
         invites = "https://pep.gg",
-        websocket = "https://a-pep.peptide.chat/ws",
-        autumn = "https://autumn.revolt.chat",
-        kjbook = "https://pepchat.github.io/android"
+        websocket = "wss://a-pep.peptide.chat/ws",
+        autumn = "https://a-pep.peptide.chat/autumn",
+        // TODO: Replace with correct URL
+        kjbook = "https://revoltchat.github.io/android"
+        // TODO: Replace with correct URL
     )
 )
 


### PR DESCRIPTION
- Updated `websocket` URL to use `wss` scheme and point to `a-pep.peptide.chat/ws`.
- Changed `autumn` URL to `a-pep.peptide.chat/autumn`.
- Added TODO comments to `kjbook` URL indicating it needs to be replaced with the correct URL.