### PR TITLE
Initialize platform on app start and enhance platform handling

### DIFF
--- a/app/src/main/java/chat/revolt/activities/MainActivity.kt
+++ b/app/src/main/java/chat/revolt/activities/MainActivity.kt
@@ -75,9 +75,12 @@ import androidx.navigation.compose.rememberNavController
 import chat.revolt.BuildConfig
 import chat.revolt.R
 import chat.revolt.RevoltApplication
+import chat.revolt.api.ApplicationPlatform
 import chat.revolt.api.HitRateLimitException
 import chat.revolt.api.RevoltAPI
+import chat.revolt.api.RevoltAPI.setPlatform
 import chat.revolt.api.RevoltHttp
+import chat.revolt.api.UrlsStorageKeys
 import chat.revolt.api.api
 import chat.revolt.api.routes.microservices.geo.queryGeo
 import chat.revolt.api.routes.microservices.health.healthCheck
@@ -189,6 +192,23 @@ class MainActivityViewModel @Inject constructor(
             doHealthCheck()
             Log.d("MainActivity", "Performing update geo state")
             updateGeoState()
+        }
+    }
+
+    /**
+     * Sets the default platform on application creation.
+     * It retrieves the platform from key-value storage and sets it in the RevoltAPI.
+     * If the platform is not found or invalid, it logs the user out.
+     */
+    fun setDefaultPlatformOnCreate() {
+        viewModelScope.launch {
+            ApplicationPlatform.fromName(
+                name = kvStorage.get(UrlsStorageKeys.PLATFORM) ?: "---"
+            )?.let { platform ->
+                setPlatform(platform)
+            } ?: run {
+                logOut()
+            }
         }
     }
 
@@ -349,6 +369,9 @@ class MainActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Set the default platform for the Platform API.
+        viewModel.setDefaultPlatformOnCreate()
 
         SentryAndroid.init(this) { options ->
             options.dsn = BuildConfig.SENTRY_DSN

--- a/app/src/main/java/chat/revolt/api/RevoltAPI.kt
+++ b/app/src/main/java/chat/revolt/api/RevoltAPI.kt
@@ -59,7 +59,14 @@ import chat.revolt.api.schemas.Channel as ChannelSchema
  */
 enum class ApplicationPlatform(val baseUrl: String) {
     REVOLT("https://api.revolt.chat"),
-    PEP("https://peptide.chat/api")
+    PEP("https://peptide.chat/api");
+
+    companion object {
+        fun fromName(name: String): ApplicationPlatform? {
+            return ApplicationPlatform.entries.find { it.name == name }
+        }
+    }
+
 }
 
 /**


### PR DESCRIPTION
-Fix #11 

- Add `setDefaultPlatformOnCreate` function to `MainActivityViewModel` to initialize the application platform from storage when the app starts. If the platform is not found or invalid, the user is logged out.
- Call `setDefaultPlatformOnCreate` in `MainActivity.onCreate`.
- Add `fromName` companion function to `ApplicationPlatform` enum to retrieve a platform by its name string.